### PR TITLE
Adding PennApps badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pennapps-main
+# pennapps-main [![PennApps](https://hackathon.badge.pw/pennapps?template=for-the-badge)](https://pennapps.com/)
 
 Do not update the code in this repository unless you really know what you're doing. Please do update the data as time passes. Only submit a Pull Request, do not commit directly.
 


### PR DESCRIPTION
Hi everyone,

I created a website to create badges for Hackathons ([hackathon.badge.pw](https://hackathon.badge.pw)), and PennApps it's one of them. I am adding the badge to this README. 

[![PennApps](https://hackathon.badge.pw/pennapps)](https://pennapps.com/)

```md
[![PennApps](https://hackathon.badge.pw/pennapps)](https://pennapps.com/)
```

It would be great if everyone at the hackathon could use the PennApps badge on their projects, and make it official.

Don't forget to give it a star 😃 [https://github.com/abranhe/hackathon-badges](https://github.com/abranhe/hackathon-badges)